### PR TITLE
limit ncss requests on thredds.ucar.edu

### DIFF
--- a/thredds/threddsConfig.xml
+++ b/thredds/threddsConfig.xml
@@ -96,7 +96,8 @@
     <allow>true</allow>
     <scour>15 min</scour>
     <maxAge>30 min</maxAge>
-    <!--maxFileDownloadSize>52428800</maxFileDownloadSize-->
+    <!-- 52428800 bytes, 50 MB -->
+    <maxFileDownloadSize>52428800</maxFileDownloadSize>
   </NetcdfSubsetService>
 
    <FeatureCollection>


### PR DESCRIPTION
NCSS requests on thredds.ucar.edu seem to be hammering the machine. We also have issues with HDF5 not properly running in single threaded mode, and we are getting file collisions. This commit is to see if limiting "big" ncss requests will help the stability of the server until we get a fix in on the java side.