### PR TITLE
remove addId elements

### DIFF
--- a/idd/idd/obsData.xml
+++ b/idd/idd/obsData.xml
@@ -17,13 +17,13 @@
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>
-    <service name="iso" serviceType="ISO" base="/thredds/iso/"/>    
+    <service name="iso" serviceType="ISO" base="/thredds/iso/"/>
   </service>
-  
+
   <service name="latest" serviceType="Resolver" base=""/>
-  
+
   <dataset name="Surface Observations">
-  
+
     <metadata inherited="true">
       <serviceName>all</serviceName>
       <authority>edu.ucar.unidata</authority>
@@ -92,7 +92,7 @@
   </dataset> <!-- End of Surface Observations -->
 
   <dataset name="Wind Profiler Observations">
-  
+
     <metadata inherited="true">
       <serviceName>all</serviceName>
       <authority>edu.ucar.unidata</authority>
@@ -138,11 +138,10 @@
         </timeCoverage>
         <variables vocabulary="CF-1"/>
       </metadata>
-      
+
       <filter>
         <include wildcard="*.bufr" atomic="true" collection="false"/>
       </filter>
-      <addID/>
       <sort>
         <lexigraphicByName increasing="false"/>
       </sort>
@@ -154,4 +153,3 @@
 
   </dataset> <!-- End Wind Profiler Observations -->
 </catalog>
-

--- a/idd/idd/radars.xml
+++ b/idd/idd/radars.xml
@@ -173,7 +173,6 @@
         <include wildcard="Level3*.nids" atomic="true" collection="false"/>
         <exclude wildcard=".*" atomic="false" collection="true"/>
       </filter>
-      <addID/>
       <sort>
         <lexigraphicByName increasing="false"/>
       </sort>
@@ -249,7 +248,6 @@
         <include wildcard="Level3*.nids" atomic="true" collection="false"/>
         <exclude wildcard=".*" atomic="false" collection="true"/>
       </filter>
-      <addID/>
       <sort>
         <lexigraphicByName increasing="false"/>
       </sort>
@@ -289,7 +287,6 @@
         <include wildcard="Level2*.ar2v" atomic="true" collection="false"/>
         <exclude wildcard=".*" atomic="false" collection="true"/>
       </filter>
-      <addID/>
       <sort>
         <lexigraphicByName increasing="false"/>
       </sort>
@@ -361,7 +358,6 @@
         <exclude wildcard="current" atomic="false" collection="true"/>
         <exclude wildcard=".*" atomic="false" collection="true"/>
       </filter>
-      <addID/>
       <sort>
         <lexigraphicByName increasing="false"/>
       </sort>
@@ -422,4 +418,3 @@
   </dataset> <!-- NEXRAD National Composites From Unidata -->
 
 </catalog>
-


### PR DESCRIPTION
`addId` elements cause xml validation errors on startup. This PR removes those elements.