### PR TITLE
Facilitate pqact sharing between tomcat and ldm on lead

### DIFF
--- a/threddsTest/pqacts/README.txt
+++ b/threddsTest/pqacts/README.txt
@@ -1,37 +1,59 @@
 This directory contains the pqact files needed to serve data from the IDD.
 
-Some files in this directory should be symlinked to the LDM etc/ directory.
-Unidata has the following directory layout:
+The files in this directory should be copied over to the LDM etc/TDS directory.
+We've created a few bash scripts to help manage this, and they may be found in
+the config.zip file:
 
------------------------------------------
-- symlinks in the LDM etc/TDS directory -
------------------------------------------
+config.zip
+    |__tdsconfig_tools/
+        |__config_update.sh
+        |__pqact_diff.sh
 
-* make symlinks to the pqacts files, for example:
-    <LDM_HOME>/etc/TDS/pqact.forecastModels -> <TDS_CONTENT_ROOT>/thredds/pqacts/pqact.forecastModels
-    <LDM_HOME>/etc/TDS/pqact.forecastProdsAndAna -> <TDS_CONTENT_ROOT>/thredds/pqacts/pqact.forecastProdsAndAna
-    <LDM_HOME>/etc/TDS/pqact.radars -> <TDS_CONTENT_ROOT>/thredds/pqacts/pqact.radars
-    <LDM_HOME>/etc/TDS/pqact.satellite -> <TDS_CONTENT_ROOT>/thredds/pqacts/pqact.satellite
-    <LDM_HOME>/etc/TDS/pqact.modelsHrrr -> <TDS_CONTENT_ROOT>/thredds/pqacts/pqact.modelsHrrr
-    <LDM_HOME>/etc/TDS/pqact.testDatasets -> <TDS_CONTENT_ROOT>/thredds/pqacts/pqact.testDatasets
-    <LDM_HOME>/etc/TDS/pqact.modelsCmc -> <TDS_CONTENT_ROOT>/thredds/pqacts/pqact.modelsCmc
-    <LDM_HOME>/etc/TDS/pqact.modelsGdas -> <TDS_CONTENT_ROOT>/thredds/pqacts/pqact.modelsGdas
+config_update.sh: Copies over to the pqacts to the ldm account.
+pqact_diff.sh: Checks for differences between the pqacts living under the ldm
+account and the pqacts in the TDS content directory (as managed by TdsConfig).
 
-Remember, you will need to add the symlinked pqacts to the LDMs
-pqact.conf file. For example:
+Warning: you will likely need to edit these scripts to change the values of the
+following ENVVARS appropriate for your system (current values shown)
+
+* LDM_PQACT_DIR="/opt/ldm/etc/TDS"
+* TDS_PQACT_DIR="/opt/tds-test/content/thredds/pqacts"
+
+Remember, you will need to add these pqacts to the LDMs pqact.conf file. 
+For example:
 
 ---------------------
 - ldmd.conf snippet -
 ---------------------
 
 #
-# THREDDS processing
+# THREDDS processing (don't forget to ensure tabs are used between 
+#                     EXEC and "pqact...")
 #
 EXEC    "pqact -f NGRID|CONDUIT|HRS|FNMOC etc/TDS/pqact.forecastModels"
 EXEC    "pqact -f NGRID|CONDUIT etc/TDS/pqact.forecastProdsAndAna"
-EXEC    "pqact -f NIMAGE etc/TDS/pqact.satellite"
+EXEC    "pqact -f HRS|NIMAGE|NOTHER etc/TDS/pqact.satellite"
 EXEC    "pqact -f HRS|FNEXRAD|NNEXRAD|CRAFT etc/TDS/pqact.radars"
 EXEC    "pqact -f NGRID|FSL2 etc/TDS/pqact.modelsHrrr"
-EXEC    "pqact -f HRS|NGRID|CONDUIT etc/TDS/pqact.testDatasets"
+EXEC    "pqact -f WMO|HRS|NGRID|CONDUIT|EXP etc/TDS/pqact.testDatasets"
+EXEC    "pqact -f IDS|HRS|NOTHER etc/TDS/pqact.ryan-test"
 EXEC    "pqact -f CMC etc/TDS/pqact.modelsCmc"
 EXEC    "pqact -f CONDUIT etc/TDS/pqact.modelsGdas"
+
+Warning: you may need to change the path to the pqact files listed in the
+ldmd.conf snippet above.
+
+After running config_update.sh, look for new pqacts and add them to the 
+ldmd.conf file.
+To ensure there are no syntax errors in the new/updated pqacts, run
+
+  ldmadmin pqactcheck
+
+If there are no issues, then you are good to go.
+If no new pqacts were added to ldmd.conf, simply run:
+
+  ldmadmin pqactHUP 
+
+otherwise, restart the ldm:
+
+  ldmadmin restart

--- a/threddsTest/pqacts/pqact.radars
+++ b/threddsTest/pqacts/pqact.radars
@@ -84,7 +84,7 @@ CRAFT	^L2-BZIP2/(....)/([0-9][0-9][0-9][0-9][0-1][0-9][0-3][0-9])([0-2][0-9][0-5
 #
 FNEXRAD	^rad/NEXRCOMP/(...)/(...)_(........)_(....)
 	PIPE	-close
-	sh etc/TDS/util/ldmfile.sh ${DATA_DIR}/native/radar/composite/gini/\2/\1/\3/Level3_Composite_\2_\1_\3_\4.gini
+	etc/TDS/util/ldmfile.sh ${DATA_DIR}/native/radar/composite/gini/\2/\1/\3/Level3_Composite_\2_\1_\3_\4.gini
 #
 # UPC generated NEXRAD Level III radar composites in GRIB format
 #

--- a/threddsTest/pqacts/pqact.satellite
+++ b/threddsTest/pqacts/pqact.satellite
@@ -77,7 +77,7 @@
 #
 NIMAGE	^satz/ch[0-9]/.*/(.*)/([12][0-9][0-9][0-9][01][0-9][0-3][0-9]) ([0-2][0-9])([0-5][0-9])/(.*)/(.*km)/
 	PIPE	-close
-	sh etc/TDS/util/ldmfile.sh ${DATA_DIR}/native/satellite/\1/\5_\6/\2/\5_\6_\1_\2_\3\4.gini
+	etc/TDS/util/ldmfile.sh ${DATA_DIR}/native/satellite/\1/\5_\6/\2/\5_\6_\1_\2_\3\4.gini
 #
 # ----------------------------------
 # - NOAAPORT NPP netCDF4 Soundings -

--- a/threddsTest/tdsconfig_tools/config_update.sh
+++ b/threddsTest/tdsconfig_tools/config_update.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+LDM_PQACT_DIR="/opt/ldm/etc/TDS"
+TDS_PQACT_DIR="/opt/tds-test/content/thredds/pqacts"
+
+
+declare -a PqactFiles=("pqact.forecastModels" \
+                       "pqact.forecastProdsAndAna" \
+                       "pqact.modelsCmc" \
+                       "pqact.modelsHrrr" \
+                       "pqact.radars" \
+                       "pqact.satellite" \
+                       "pqact.modelsGdas" \
+                       "pqact.ryan-test" \
+                       "pqact.testDatasets")
+
+declare -a AuxDirs=( "util" )
+
+# make sure we are in the correct directory
+echo "Change directory to ${LDM_PQACT_DIR}" 
+eval cd ${LDM_PQACT_DIR}
+
+# refresh pqact files based on TdsConfig
+echo "Refresh pqacts"
+for pqact in ${PqactFiles[@]}; do
+    echo "...refreshing $pqact"
+    eval rm ./${pqact}
+    eval cp ${TDS_PQACT_DIR}/${pqact} .
+done
+
+# refresh directories based on what is in TdsConfig
+echo "Refresh directories"
+for auxDir in ${AuxDirs[@]}; do
+    echo "...refreshing ${auxDir}"
+    eval rm -r ./${auxDir}
+    eval cp -r ${TDS_PQACT_DIR}/${auxDir} .
+done
+
+# make sure things in util are executable by LDM
+echo "Changing permissions in util directory"
+chmod -R u+x ./util
+
+echo "finished!"

--- a/threddsTest/tdsconfig_tools/pqact_diff.sh
+++ b/threddsTest/tdsconfig_tools/pqact_diff.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+LDM_PQACT_DIR="/opt/ldm/etc/TDS"
+TDS_PQACT_DIR="/opt/tds-test/content/thredds/pqacts"
+
+
+declare -a PqactFiles=("pqact.forecastModels" \
+                       "pqact.forecastProdsAndAna" \
+                       "pqact.modelsCmc" \
+                       "pqact.modelsHrrr" \
+                       "pqact.radars" \
+                       "pqact.satellite" \
+                       "pqact.modelsGdas" \
+                       "pqact.ryan-test" \
+                       "pqact.testDatasets")
+
+# make sure we are in the correct directory
+echo "Change directory to ${LDM_PQACT_DIR}" 
+eval cd ${LDM_PQACT_DIR}
+
+echo "Checking diffs"
+for pqact in ${PqactFiles[@]}; do
+    echo "diff for ${pqact} ..."
+    eval diff ./$pqact ${TDS_PQACT_DIR}/${pqact}
+done


### PR DESCRIPTION
This PR aims to help manage the sharing of pqacts between the TDS (managed via TdsConfig) and the LDM on lead (i.e. threddsTest). This also fixes an issue with LDM logging when executing actions in the pqact files with sh.