### PR TITLE
Updates for move from NPP to NOAA-20

### DIFF
--- a/threddsTest/idd/satellite.xml
+++ b/threddsTest/idd/satellite.xml
@@ -417,7 +417,7 @@
         </dataset><!-- End of Sounder Derived Products -->
       </dataset><!-- End of Satellite Sounder Data -->
     </dataset><!-- End of NESDIS GOES Satellite Data -->
-    <dataset name="NESDIS S-NPP Satellite Data">
+    <dataset name="NESDIS NOAA-20 Satellite Data">
       <metadata inherited="true">
         <serviceName>nongrid</serviceName>
         <documentation xlink:href="http://www.unidata.ucar.edu/data/satellite_data_2.html" xlink:title="Satellite Data Available Through Unidata " />
@@ -433,14 +433,14 @@
           <duration>14 days</duration>
         </timeCoverage>
       </metadata>
-      <datasetScan name="S-NPP VIIRS Swath Imagery" ID="snpp-viirs" path="satellite/snpp/viirs" location="${DATA_DIR}/native/satellite/NPP/VIIRS" >
+      <datasetScan name="NOAA-20 VIIRS NCC Swath Imagery" ID="noaa20-viirs" path="satellite/snpp/viirs" location="${DATA_DIR}/native/satellite/NOAA20/VIIRS" >
         <filter>
           <include wildcard="*.nc4"/>
           <include wildcard="*.nc"/>
         </filter>
         <addDatasetSize/>
       </datasetScan>
-      <datasetScan name="S-NPP NUCAPS Soundings" ID="snpp-nucaps" path="satellite/snpp/nucaps" location="${DATA_DIR}/native/satellite/NPP/NUCAPS" >
+      <datasetScan name="NOAA-20 NUCAPS Soundings" ID="noaa20-nucaps" path="satellite/snpp/nucaps" location="${DATA_DIR}/native/satellite/NOAA20/NUCAPS" >
         <filter>
           <include wildcard="*.nc4"/>
           <include wildcard="*.nc"/>

--- a/threddsTest/pqacts/pqact.satellite
+++ b/threddsTest/pqacts/pqact.satellite
@@ -80,7 +80,7 @@ NIMAGE	^satz/ch[0-9]/.*/(.*)/([12][0-9][0-9][0-9][01][0-9][0-3][0-9]) ([0-2][0-9
 	etc/TDS/util/ldmfile.sh ${DATA_DIR}/native/satellite/\1/\5_\6/\2/\5_\6_\1_\2_\3\4.gini
 #
 # ----------------------------------
-# - NOAAPORT NPP netCDF4 Soundings -
+# - NOAAPORT NOAA-20 NUCAPS netCDF4 Soundings -
 # ----------------------------------
 #
 HRS	^IUTN(..) KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
@@ -88,7 +88,7 @@ HRS	^IUTN(..) KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
 	etc/TDS/ldm-alchemy/strip_header.py ${DATA_DIR}/native/satellite/NPP/NUCAPS/\1/NUCAPS_\1_(\2:yyyy)(\2:mm)\2_\3.nc4
 #
 # -----------------------------------
-# - NOAAPORT NPP netCDF4 Swath Data -
+# - NOAAPORT NOAA-20 netCDF4 Swath Data -
 # -----------------------------------
 #
 NOTHER	^TIPB01 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
@@ -103,13 +103,13 @@ NOTHER	^TIPB05 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
 NOTHER	^TIPB10 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
 	PIPE	-close
 	etc/TDS/ldm-alchemy/strip_header.py -d ${DATA_DIR}/native/satellite/NPP/VIIRS/Alaska/ConstantContrast/VIIRS_Alaska_ConstantContrast_(\1:yyyy)(\1:mm)\1_\2.nc4
-NOTHER	^TIPC10 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
+NOTHER	^TIPD10 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
 	PIPE	-close
 	etc/TDS/ldm-alchemy/strip_header.py -d ${DATA_DIR}/native/satellite/NPP/VIIRS/CONUS/ConstantContrast/VIIRS_CONUS_ConstantContrast_(\1:yyyy)(\1:mm)\1_\2.nc4
-NOTHER	^TIPI10 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
+NOTHER	^TIPH10 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
 	PIPE	-close
 	etc/TDS/ldm-alchemy/strip_header.py -d ${DATA_DIR}/native/satellite/NPP/VIIRS/Pacific/ConstantContrast/VIIRS_Pacific_ConstantContrast_(\1:yyyy)(\1:mm)\1_\2.nc4
-NOTHER	^TIPQ10 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
+NOTHER	^TIPP10 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
 	PIPE	-close
 	etc/TDS/ldm-alchemy/strip_header.py -d ${DATA_DIR}/native/satellite/NPP/VIIRS/PuertoRico/ConstantContrast/VIIRS_PuertoRico_ConstantContrast_(\1:yyyy)(\1:mm)\1_\2.nc4
 #


### PR DESCRIPTION
Looks like NOAAPORT has moved/is moving some things from NPP to NOAA-20:

* NUCAPS Soundings (already done): https://www.weather.gov/media/notification/scn19-59nucaps_soundings.pdf
* VIIRS Near-constant contrast (NCC) imagery: https://www.weather.gov/media/notification/scn19-66viirs_ncc_sbn.pdf

The first one is already done, and really on needs some catalog updates for naming--the data are matching the same pattern. For the NCC, the new data started yesterday, so I went ahead and replaced the old data with the new. The old data will stop a month from now, at which point we may need to remove the Alaska imagery, at least the NCC.

@lesserwhirls I'll leave to you to merge (and please update the server?) when this isn't at risk of breaking a workshop.