### PR TITLE
Update catalog for GINI changes

### DIFF
--- a/idd/idd/satellite.xml
+++ b/idd/idd/satellite.xml
@@ -10,17 +10,7 @@
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>
     <service name="iso" serviceType="ISO" base="/thredds/iso/"/>
-  <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
-  </service>
-  <service name="all2" serviceType="Compound" base="">
-    <service name="ncdods2" serviceType="OPENDAP" base="/thredds/dodsC/" />
-    <service name="wcs2" serviceType="WCS" base="/thredds/wcs/"/>
-    <service name="wms2" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss2" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
-    <service name="ncml2" serviceType="NCML" base="/thredds/ncml/"/>
-    <service name="uddc2" serviceType="UDDC" base="/thredds/uddc/"/>
-    <service name="iso2" serviceType="ISO" base="/thredds/iso/"/>
-    <service name="cdmremote2" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
+    <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
   </service>
   <service name="latest" serviceType="Resolver" base="" />
   
@@ -119,34 +109,6 @@
       -->
 
       <dataset name="Imager Data (GINI)">
-        <dataset name="Shortwave IR (3.9um)">
-          <datasetScan name="West CONUS 4km" ID="SSEC/IDD-Satellite/3.9/WEST-CONUS_4km" path="satellite/3.9/WEST-CONUS_4km" location="${DATA_DIR}/native/satellite/3.9/WEST-CONUS_4km/">
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-          <dataset name="West CONUS 4km Aggregation" ID="SSEC/IDD-Satellite/3.9/WEST-CONUS_4km-Agg" urlPath="satellite/3.9/WEST-CONUS_4km">
-            <serviceName>all2</serviceName>
-            <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
-              <aggregation dimName="time" type="joinExisting">
-                <scan dateFormatMark="WEST-CONUS_4km_3.9_#yyyyMMdd_HHmm" location="${DATA_DIR}/native/satellite/3.9/WEST-CONUS_4km/" suffix=".gini" />
-              </aggregation>
-            </netcdf>
-          </dataset>
-          <datasetScan name="Hawaii 4km" ID="SSEC/IDD-Satellite/3.9/HI-REGIONAL_4km" path="satellite/3.9/HI-REGIONAL_4km" location="${DATA_DIR}/native/satellite/3.9/HI-REGIONAL_4km/">
-             <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-          <datasetScan name="Alaska 8km" ID="SSEC/IDD-Satellite/3.9/AK-REGIONAL_8km" path="satellite/3.9/AK-REGIONAL_8km" location="${DATA_DIR}/native/satellite/3.9/AK-REGIONAL_8km/">
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-        </dataset>
         <datasetScan name="Water Vapor (6.5 / 5.7 um)" ID="SSEC/IDD-Satellite/WV" path="satellite/WV" location="${DATA_DIR}/native/satellite/WV/">
           <metadata inherited="true">
             <geospatialCoverage>
@@ -207,12 +169,6 @@
           </filter>
           <addDatasetSize/>
         </datasetScan>
-        <datasetScan name="CO2 (13.3 um)" ID="SSEC/IDD-Satellite/13.3" path="satellite/13.3" location="${DATA_DIR}/native/satellite/13.3/" >
-          <filter>
-            <include wildcard="*.gini"/>
-          </filter>
-          <addDatasetSize/>
-        </datasetScan>
         <datasetScan name="Visible" ID="SSEC/IDD-Satellite/VIS" path="satellite/VIS" location="${DATA_DIR}/native/satellite/VIS/">
           <metadata inherited="true">
             <geospatialCoverage>
@@ -242,192 +198,36 @@
           <addDatasetSize/>
         </datasetScan>
       </dataset><!-- end of Satellite Imager Data -->
-      <!--
-
-         Satellite Sounder Data (GINI) 
-
-      -->
-      <dataset name="Sounder Data">
-        <dataset name="Sounder Images">
-          <datasetScan name="SOUND-3.98" ID="SSEC/IDD-Satellite/SOUND-3.98" path="satellite/SOUND-3.98" location="${DATA_DIR}/native/satellite/SOUND-3.98/" >
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-          <datasetScan name="SOUND-4.45" ID="SSEC/IDD-Satellite/SOUND-4.45" path="satellite/SOUND-4.45" location="${DATA_DIR}/native/satellite/SOUND-4.45/" >
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-          <datasetScan name="SOUND-6.51" ID="SSEC/IDD-Satellite/SOUND-6.51" path="satellite/SOUND-6.51" location="${DATA_DIR}/native/satellite/SOUND-6.51/" >
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-          <datasetScan name="SOUND-7.02" ID="SSEC/IDD-Satellite/SOUND-7.02" path="satellite/SOUND-7.02" location="${DATA_DIR}/native/satellite/SOUND-7.02/" >
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-          <datasetScan name="SOUND-7.43" ID="SSEC/IDD-Satellite/SOUND-7.43" path="satellite/SOUND-7.43" location="${DATA_DIR}/native/satellite/SOUND-7.43/" >
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-          <datasetScan name="SOUND-11.03" ID="SSEC/IDD-Satellite/SOUND-11.03" path="satellite/SOUND-11.03" location="${DATA_DIR}/native/satellite/SOUND-11.03/" >
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-          <datasetScan name="SOUND-14.06" ID="SSEC/IDD-Satellite/SOUND-14.06" path="satellite/SOUND-14.06" location="${DATA_DIR}/native/satellite/SOUND-14.06/" >
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-          <datasetScan name="Visible" ID="SSEC/IDD-Satellite/SOUND-VIS" path="satellite/SOUND-VIS" location="${DATA_DIR}/native/satellite/SOUND-VIS/" >
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-        </dataset>
         <!--
 
          Sounder Derived Products 
 
         -->
-        <dataset name="Sounder Derived Products">
-          <datasetScan name="Lifted Index" ID="SSEC/IDD-Satellite/LI" path="satellite/LI" location="${DATA_DIR}/native/satellite/LI/">
-            <metadata inherited="true">
-              <geospatialCoverage>
-                <northsouth>
-                  <start>7.87101</start>
-                  <size>38.95801</size>
-                  <units>degrees_north</units>
-                </northsouth>
-                <eastwest>
-                  <start>-141.06373</start>
-                  <size>128.35151</size>
-                  <units>degrees_east</units>
-                </eastwest>
-                <updown>
-                  <start>0.0</start>
-                  <size>0.0</size>
-                  <units>km</units>
-                </updown>
-              </geospatialCoverage>
-              <variables vocabulary="">
-                <variable name="LI" vocabulary_name="" units="N/A">Lifted Index LI</variable>
-              </variables>
-            </metadata>
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-          <datasetScan name="Precipitable Water" ID="SSEC/IDD-Satellite/PW" path="satellite/PW" location="${DATA_DIR}/native/satellite/PW/" >
-            <metadata inherited="true">
-              <geospatialCoverage>
-                <northsouth>
-                  <start>7.87101</start>
-                  <size>38.95801</size>
-                  <units>degrees_north</units>
-                </northsouth>
-                <eastwest>
-                  <start>-141.06373</start>
-                  <size>128.35151</size>
-                  <units>degrees_east</units>
-                </eastwest>
-                <updown>
-                  <start>0.0</start>
-                  <size>0.0</size>
-                  <units>km</units>
-                </updown>
-              </geospatialCoverage>
-              <variables vocabulary="">
-                <variable name="PW" vocabulary_name="" units="N/A">Precipitable Water PW</variable>
-              </variables>
-            </metadata>
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-          <datasetScan name="Cloud Top Pressure" ID="SSEC/IDD-Satellite/CTP" path="satellite/CTP" location="${DATA_DIR}/native/satellite/CTP/">
-            <metadata inherited="true">
-              <geospatialCoverage>
-                <northsouth>
-                  <start>7.87101</start>
-                  <size>38.95801</size>
-                  <units>degrees_north</units>
-                </northsouth>
-                <eastwest>
-                  <start>-141.06373</start>
-                  <size>128.35151</size>
-                  <units>degrees_east</units>
-                </eastwest>
-                <updown>
-                  <start>0.0</start>
-                  <size>0.0</size>
-                  <units>km</units>
-                </updown>
-              </geospatialCoverage>
-              <variables vocabulary="">
-                <variable name="CTP" vocabulary_name="" units="N/A">Cloud Top Pressure or Height</variable>
-              </variables>
-            </metadata>
-            <filter>
-              <include wildcard="*.gini"/>
-            </filter>
-            <addDatasetSize/>
-          </datasetScan>
-          <dataset name="Surface Skin Temperature">
-            <metadata inherited="true">
-              <geospatialCoverage>
-                <northsouth>
-                  <start>7.87101</start>
-                  <size>38.95801</size>
-                  <units>degrees_north</units>
-                </northsouth>
-                <eastwest>
-                  <start>-141.06373</start>
-                  <size>128.35151</size>
-                  <units>degrees_east</units>
-                </eastwest>
-                <updown>
-                  <start>0.0</start>
-                  <size>0.0</size>
-                  <units>km</units>
-                </updown>
-              </geospatialCoverage>
-              <variables vocabulary="">
-                <variable name="SFC_T" vocabulary_name="" units="N/A">Surface Skin Temperature</variable>
-              </variables>
-            </metadata>
-            <datasetScan name="SUPER NATIONAL 1km" ID="SSEC/IDD-Satellite/SFC-T/SUPER-NATIONAL_1km" path="satellite/SFC-T/SUPER-NATIONAL_1km" location="${DATA_DIR}/native/satellite/SFC-T/SUPER-NATIONAL_1km/" >
-              <filter>
-                <include wildcard="*.gini"/>
-              </filter>
-              <addDatasetSize/>
-            </datasetScan>
-            <dataset name="Super National 1km Aggregation" ID="SSEC/IDD-Satellite/SFC-T/SUPER-NATIONAL_1km-Agg" urlPath="satellite/SFC-T/SUPER-NATIONAL_1km">
-              <serviceName>all2</serviceName>
-              <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
-                <aggregation dimName="time" type="joinExisting">
-                  <scan dateFormatMark="SUPER-NATIONAL_1km_SFC-T_#yyyyMMdd_HHmm" location="${DATA_DIR}/native/satellite/SFC-T/SUPER-NATIONAL_1km/" suffix=".gini" />
-                </aggregation>
-              </netcdf>
-            </dataset>
-          </dataset>
-        </dataset><!-- End of Sounder Derived Products -->
-      </dataset><!-- End of Satellite Sounder Data -->
+      <dataset name="Sounder Derived Products">
+        <datasetScan name="Precipitable Water" ID="SSEC/IDD-Satellite/PW" path="satellite/PW" location="${DATA_DIR}/native/satellite/PW/" >
+          <metadata inherited="true">
+            <variables vocabulary="">
+              <variable name="PW" vocabulary_name="" units="N/A">Precipitable Water PW</variable>
+            </variables>
+          </metadata>
+          <filter>
+            <include wildcard="*.gini"/>
+          </filter>
+          <addDatasetSize/>
+        </datasetScan>
+        <datasetScan name="Rainfall Rate" ID="SSEC/IDD-Satellite/RR" path="satellite/PRXX" location="${DATA_DIR}/native/satellite/PW/" >
+          <filter>
+            <include wildcard="*.gini"/>
+          </filter>
+          <addDatasetSize/>
+        </datasetScan>
+        <datasetScan name="Percent Normal Total Precipitable Water" ID="SSEC/IDD-Satellite/PCT" path="satellite/60" location="${DATA_DIR}/native/satellite/PW/" >
+          <filter>
+            <include wildcard="*.gini"/>
+          </filter>
+          <addDatasetSize/>
+        </datasetScan>
+      </dataset><!-- End of Sounder Derived Products -->
     </dataset><!-- End of NESDIS GOES Satellite Data -->
   </dataset><!-- End of Satellite Data -->
 </catalog>


### PR DESCRIPTION
A whole bunch of legacy products are no more, like sounders and many of the derived products, so remove them. Also remove channels that are no longer available.

There are still some NHEM composites showing up, so keep vis, IR, WV.

Also, I went ahead and added a few derived products in GINI (rainfall rate, percent normal TPW) that were on disk but not served. While these particular GINI products are slated to go away, they will be replaced by equivalent composites based on newer satellites. We can switch over to those here when NOAAPORT does.