### PR TITLE
prod --> .* for GFS

### DIFF
--- a/idd/pqacts/pqact.forecastModels
+++ b/idd/pqacts/pqact.forecastModels
@@ -12,13 +12,13 @@
 #
 # GFS Global 0.25 degree analysis only
 #
-CONDUIT	^data/nccf/com/gfs/prod/gfs\.(........)/(..).*pgrb2\.0p25\.a
+CONDUIT	^data/nccf/com/gfs/.*/gfs\.(........)/(..).*pgrb2\.0p25\.a
 	FILE
 	${DATA_DIR}/native/grid/NCEP/GFS/Global_0p25deg_ana/GFS_Global_0p25deg_ana_\1_\200.grib2
 #
 # GFS Global 0.25 degree forecast only
 #
-CONDUIT	^data/nccf/com/gfs/prod/gfs\.(........)/(..).*pgrb2\.0p25\.f
+CONDUIT	^data/nccf/com/gfs/.*/gfs\.(........)/(..).*pgrb2\.0p25\.f
 	FILE
 	${DATA_DIR}/native/grid/NCEP/GFS/Global_0p25deg/GFS_Global_0p25deg_\1_\200.grib2
 #
@@ -26,25 +26,25 @@ CONDUIT	^data/nccf/com/gfs/prod/gfs\.(........)/(..).*pgrb2\.0p25\.f
 #
 # GFS Global 0.5 Degree
 #
-CONDUIT	^data/nccf/com/gfs/prod/gfs\.(........)/(..).*pgrb2\.0p50\.f
+CONDUIT	^data/nccf/com/gfs/.*/gfs\.(........)/(..).*pgrb2\.0p50\.f
 	FILE	-metadata
 	${DATA_DIR}/native/grid/NCEP/GFS/Global_0p5deg/GFS_Global_0p5deg_\1_\200.grib2
 #
 # GFS Global 0.5 Degree Analysis
 #
-CONDUIT	^data/nccf/com/gfs/prod/gfs\.(........)/(..).*pgrb2\.0p50\.a
+CONDUIT	^data/nccf/com/gfs/.*/gfs\.(........)/(..).*pgrb2\.0p50\.a
 	FILE	-metadata
 	${DATA_DIR}/native/grid/NCEP/GFS/Global_0p5deg_ana/GFS_Global_0p5deg_ana_\1_\200.grib2
 #
 # GFS Global 1.0 Degree
 #
-CONDUIT	^data/nccf/com/gfs/prod/gfs\.(........)/(..).*pgrb2\.1p00\.f
+CONDUIT	^data/nccf/com/gfs/.*/gfs\.(........)/(..).*pgrb2\.1p00\.f
 	FILE	-metadata
 	${DATA_DIR}/native/grid/NCEP/GFS/Global_onedeg/GFS_Global_onedeg_\1_\200.grib2
 #
 # GFS Global 1.0 Degree Analysis
 #
-CONDUIT	^data/nccf/com/gfs/prod/gfs\.(........)/(..).*pgrb2\.1p00\.a
+CONDUIT	^data/nccf/com/gfs/.*/gfs\.(........)/(..).*pgrb2\.1p00\.a
 	FILE	-metadata
 	${DATA_DIR}/native/grid/NCEP/GFS/Global_onedeg_ana/GFS_Global_onedeg_ana_\1_\200.grib2
 #


### PR DESCRIPTION
As per the message sent via the CODUIT list on 06/28/2022:

> *As a reminder for CONDUIT users*,
> *the impact of the change to all model data to use version numbers means
> that data will be inserted into the CONDUIT LDM feeds at NCEP with a
> version number in its directory path instead of "prod". These are the same
> version numbers used for model data on our NOMADS service
> <https://nomads.ncep.noaa.gov/>.*
> (Example: data/nccf/com/gfs/*prod*/gfs.20220626/12/atmos/gfs.t12z.pgrb2.0p25.f000
> *--->* data/nccf/com/gfs/*v16.2*
> /gfs.20220626/12/atmos/gfs.t12z.pgrb2.0p25.f000)