### PR TITLE
Fix ncss service base paths

### DIFF
--- a/awsL2/idd/radars.xml
+++ b/awsL2/idd/radars.xml
@@ -17,7 +17,7 @@
     <service name="ncdods" serviceType="OPENDAP" base="/thredds/dodsC/"/>
     <service name="wcsServer" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wmsServer" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>

--- a/idd/idd/forecastProdsAndAna.xml
+++ b/idd/idd/forecastProdsAndAna.xml
@@ -11,7 +11,7 @@
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>

--- a/idd/idd/radars.xml
+++ b/idd/idd/radars.xml
@@ -17,7 +17,7 @@
     <service name="ncdods" serviceType="OPENDAP" base="/thredds/dodsC/"/>
     <service name="wcsServer" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wmsServer" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>

--- a/idd/idd/satellite.xml
+++ b/idd/idd/satellite.xml
@@ -5,7 +5,7 @@
     <service name="ncdods" serviceType="OPENDAP" base="/thredds/dodsC/" />
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/" />
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>

--- a/rdavm/catalog_ds131.1.xml
+++ b/rdavm/catalog_ds131.1.xml
@@ -7,7 +7,7 @@
     
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="opendap" serviceType="OPENDAP" base="/thredds/dodsC/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>

--- a/rdavm/catalog_ds298.0.xml
+++ b/rdavm/catalog_ds298.0.xml
@@ -7,7 +7,7 @@
     
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="opendap" serviceType="OPENDAP" base="/thredds/dodsC/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>

--- a/rdavm/catalog_ds316.0.xml
+++ b/rdavm/catalog_ds316.0.xml
@@ -7,7 +7,7 @@
   <service name="all" serviceType="Compound" base="">
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="opendap" serviceType="OPENDAP" base="/thredds/dodsC/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>

--- a/rdavm/catalog_ds502.0.xml
+++ b/rdavm/catalog_ds502.0.xml
@@ -7,7 +7,7 @@
   <service name="all" serviceType="Compound" base="">
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="opendap" serviceType="OPENDAP" base="/thredds/dodsC/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>

--- a/rdavm/catalog_ds601.0.xml
+++ b/rdavm/catalog_ds601.0.xml
@@ -7,7 +7,7 @@
   <service name="all" serviceType="Compound" base="">
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="opendap" serviceType="OPENDAP" base="/thredds/dodsC/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>

--- a/rdavm/catalog_ds631.0.xml
+++ b/rdavm/catalog_ds631.0.xml
@@ -7,7 +7,7 @@
     
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="opendap" serviceType="OPENDAP" base="/thredds/dodsC/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>

--- a/thredds/tdscapabilities/authTest.xml
+++ b/thredds/tdscapabilities/authTest.xml
@@ -11,7 +11,7 @@
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
     <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
     <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>

--- a/threddsTest/cf_examples.xml
+++ b/threddsTest/cf_examples.xml
@@ -4,7 +4,7 @@
 
   <service name="all" serviceType="Compound" base="">
     <service name="opendap" serviceType="OPENDAP" base="/thredds/dodsC/"/>
-    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="ncssPoint" serviceType="NetcdfSubset" base="/thredds/ncss/point/"/>
     <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/" />
   </service>
 


### PR DESCRIPTION
Fix the catalog service base paths for ncss to use /ncss/grid/ or /ncss/point/ instead of /ncss/