### PR TITLE
Workaround to fix HTTPServer service in textProds

### DIFF
--- a/idd/idd/textProds.xml
+++ b/idd/idd/textProds.xml
@@ -4,9 +4,13 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          name="Unidata THREDDS Data Server - NCEP models">
 
+  <service name="OnlyHTTPServer" serviceType="Compound" base="">
+    <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
+  </service>
+
   <datasetScan name="NOAAPORT Text Products" ID="noaaport-text" path="noaaport/text" location="${DATA_DIR}/native/text" >
     <metadata inherited="true">
-      <serviceName>HTTPServer</serviceName>
+      <serviceName>OnlyHTTPServer</serviceName>
     </metadata>
     <filter>
       <include wildcard="*.txt"/>


### PR DESCRIPTION
This is a workaround, I don't think that it should be necessary to define a compound service to use one of the base services. If you agree, I will open a GH issue in TDS to fix the actual bug (and add a task to remove this workaround here).

This should fix the error we are currently getting on [thredds-dev](https://thredds-dev.unidata.ucar.edu/thredds/catalog/noaaport/text/metar/catalog.html):
```
Caused by: java.lang.AssertionError
	at thredds.server.catalogservice.CatalogViewContextParser.makeFileServerUrl(CatalogViewContextParser.java:317)
	at thredds.server.catalogservice.CatalogViewContextParser.getCatalogItemHref(CatalogViewContextParser.java:231)
	at thredds.server.catalogservice.CatalogViewContextParser.populateItemContext(CatalogViewContextParser.java:135)
	at thredds.server.catalogservice.CatalogViewContextParser.addCatalogItems(CatalogViewContextParser.java:126)
	at thredds.server.catalogservice.CatalogViewContextParser.populateItemContext(CatalogViewContextParser.java:145)
	at thredds.server.catalogservice.CatalogViewContextParser.addCatalogItems(CatalogViewContextParser.java:126)
	at thredds.server.catalogservice.CatalogViewContextParser.getCatalogViewContext(CatalogViewContextParser.java:64)
	at thredds.server.catalogservice.CatalogServiceController.handleHTMLRequest(CatalogServiceController.java:98)
	at thredds.server.catalogservice.CatalogServiceController.handleRequest(CatalogServiceController.java:67)
	at jdk.internal.reflect.GeneratedMethodAccessor67.invoke(Unknown Source)
```