### PR TITLE
Fix pqact for blended satellite products

### DIFF
--- a/idd/pqacts/pqact.satellite
+++ b/idd/pqacts/pqact.satellite
@@ -47,11 +47,11 @@ NOTHER	^TIPP10 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
 # -----------------------------------
 #
 NOTHER	^TITX38 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
-	FILE	-close
-	etc/TDS/ldm-alchemy/strip_header.py -d ${DATA_DIR}/native/satellite/Blended/TotalPrecipitableWater/Blended_TotalPrecipitableWater_(\1:yyyy)(\1:mm)\1_\2.nc4
+	PIPE	-close
+	etc/TDS/ldm-alchemy/strip_header.py ${DATA_DIR}/native/satellite/Blended/TotalPrecipitableWater/Blended_TotalPrecipitableWater_(\1:yyyy)(\1:mm)\1_\2.nc4
 NOTHER	^TITX39 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
-	FILE	-close
-	etc/TDS/ldm-alchemy/strip_header.py -d ${DATA_DIR}/native/satellite/Blended/RainfallRate/Blended_RainfallRate_(\1:yyyy)(\1:mm)\1_\2.nc4
+	PIPE	-close
+	etc/TDS/ldm-alchemy/strip_header.py ${DATA_DIR}/native/satellite/Blended/RainfallRate/Blended_RainfallRate_(\1:yyyy)(\1:mm)\1_\2.nc4
 NOTHER	^TICX70 KNES ([0-9][0-9])([0-9][0-9][0-9][0-9])
-	FILE	-close
-	etc/TDS/ldm-alchemy/strip_header.py -d ${DATA_DIR}/native/satellite/Blended/PctTPW/Blended_PercentNormalTPW_(\1:yyyy)(\1:mm)\1_\2.nc4
+	PIPE	-close
+	etc/TDS/ldm-alchemy/strip_header.py ${DATA_DIR}/native/satellite/Blended/PctTPW/Blended_PercentNormalTPW_(\1:yyyy)(\1:mm)\1_\2.nc4


### PR DESCRIPTION
Was not quite the right invocation of the strip_header script. Somehow this was resulting in the raw products (including WMO header) being written to disk. Also this had the `-d` (decompress) flag being passed, which wouldn't run correctly for this data.