### PR TITLE
Fix level2 data serving through the radar server

### DIFF
--- a/idd/radar/radarCollections.xml
+++ b/idd/radar/radarCollections.xml
@@ -3,7 +3,7 @@
   <service name="radarServer" serviceType="QueryCapability" base="/thredds/radarServer/" />
   <dataset name="Radar Data">
     <datasetScan name="NEXRAD Level II Radar from IDD" collectionType="TimeSeries" ID="nexrad/level2/IDD" path="nexrad/level2/IDD" location="${DATA_DIR}/native/radar/level2">
-      <radarCollection layout="STATION/yyyyMMdd" dateRegex="(\d{8}_\d{6})\.ar2v$" dateFormat="yyyyMMdd_HHmmss" />
+      <radarCollection layout="STATION/yyyyMMdd" dateRegex="(\d{8}_\d{4})\.ar2v$" dateFormat="yyyyMMdd_HHmm" />
       <metadata inherited="true">
         <dataType>Radial</dataType>
         <dataFormat>NEXRAD2</dataFormat>


### PR DESCRIPTION
Since the production machine is still using the old perl-based handler, we only have filenames with time out to the minute, not second.