### PR TITLE
Use timeUnitConverter

### DIFF
--- a/idd/idd/forecastProdsAndAna.xml
+++ b/idd/idd/forecastProdsAndAna.xml
@@ -94,6 +94,8 @@
         <tdm rewrite="test" rescan="0 0/15 * * * ? *" />
         <gribConfig>
           <filesSort increasing="false" />
+          <!-- Convert from hours to minutes so that all grib files in collection have the same units -->
+          <timeUnitConvert from="1" to="0"/>
         </gribConfig>
       </featureCollection>
 

--- a/idd/idd/forecastProdsAndAna.xml
+++ b/idd/idd/forecastProdsAndAna.xml
@@ -94,8 +94,8 @@
         <tdm rewrite="test" rescan="0 0/15 * * * ? *" />
         <gribConfig>
           <filesSort increasing="false" />
-          <!-- Convert from hours to minutes so that all grib files in collection have the same units -->
-          <timeUnitConvert from="1" to="0"/>
+          <!-- Convert from minutes to hours so that all grib files in collection have the same units -->
+          <timeUnitConvert from="0" to="1"/>
         </gribConfig>
       </featureCollection>
 


### PR DESCRIPTION
Convert from hours to minutes so that all grib files in collection have the same units, and so the "best" does not have "mixed_interval" times units/ variable names.

I tested this catalog change with the latest snapshot on thredds-dev.

Any preference for minutes or hours as the unit?