### PR TITLE
Add notebooks for preprocessed datasets

### DIFF
--- a/threddsTest/notebooks/normalized_dataset.ipynb
+++ b/threddsTest/notebooks/normalized_dataset.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"https://unidata.ucar.edu/images/logos/badges/badge_unidata_100.jpg\" alt=\"Unidata Logo\" style=\"float: right; height: 98px;\">\n",
+    "\n",
+    "# Siphon THREDDS Jupyter Notebook - Visualizing Preprocessed Data - Normalized\n",
+    "\n",
+    "## Dataset: {{datasetName}}\n",
+    "___"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dependencies:\n",
+    "* *Siphon*: `pip install siphon`\n",
+    "* *xarray*: `pip install xarray` or 'conda install -c conda-forge xarray dask netCDF4 bottleneck'\n",
+    "* *ipywidgets*:`pip install ipywidgets` or `conda install -c conda-forge ipywidgets`  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "from siphon.catalog import TDSCatalog\n",
+    "import ipywidgets as widgets\n",
+    "from ipywidgets import interact"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Access a dataset\n",
+    "\n",
+    "With the TDS catalog url, we can use Siphon to get the dataset named `datasetName`.\\\n",
+    "Siphon's `remote-access` returns a `Dataset` object, which opens the remote dataset and provides access to its metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catUrl = \"{{catUrl}}\"\n",
+    "datasetName = \"{{datasetName}}\"\n",
+    "catalog = TDSCatalog(catUrl)\n",
+    "ds = catalog.datasets[datasetName]\n",
+    "dataset = ds.remote_access(use_xarray=True)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Normalized Data\n",
+    "\n",
+    "$z$: &ensp; Data point \\\n",
+    "$z_{\\text{min}}$: &ensp; Minimum data point value in the variable \\\n",
+    "$z_{\\text{max}}$: &ensp; Maximum data point value in the variable \\\n",
+    "$n$: &ensp; Normalized data point\n",
+    "\n",
+    "$n = \\cfrac{z - z_{\\text{min}}}{z_{\\text{max}} - z_{\\text{min}}}$"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### List of variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list(dataset.data_vars)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Display a variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dropdown = widgets.Dropdown(options = list(dataset.data_vars), description = 'Select a variable')\n",
+    "\n",
+    "def plot_variable(data_var):\n",
+    "\tif len(dataset[data_var].shape) > 2:\n",
+    "\t\tdataset[data_var].plot()\n",
+    "\t\n",
+    "interact(plot_variable, data_var = dropdown)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16 | packaged by conda-forge | (main, Feb  1 2023, 21:39:03) \n[GCC 11.3.0]"
+  },
+  "orig_nbformat": 4,
+  "viewer_info": {
+   "accepts": {
+    "accept_datasetIDs": [
+     "normalized.*"
+    ]
+   },
+   "description": "Preprocessed Dataset Visualization - Normalized"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b5cfa023891fceef02537f80a4c6e95b77988fb973cdb16a51cdb785092210be"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/threddsTest/notebooks/standardized_dataset.ipynb
+++ b/threddsTest/notebooks/standardized_dataset.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"https://unidata.ucar.edu/images/logos/badges/badge_unidata_100.jpg\" alt=\"Unidata Logo\" style=\"float: right; height: 98px;\">\n",
+    "\n",
+    "# Siphon THREDDS Jupyter Notebook - Visualizing Preprocessed Data - Standardized\n",
+    "\n",
+    "## Dataset: {{datasetName}}\n",
+    "___"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dependencies:\n",
+    "* *Siphon*: `pip install siphon`\n",
+    "* *xarray*: `pip install xarray` or 'conda install -c conda-forge xarray dask netCDF4 bottleneck'\n",
+    "* *ipywidgets*:`pip install ipywidgets` or `conda install -c conda-forge ipywidgets`  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "from siphon.catalog import TDSCatalog\n",
+    "import ipywidgets as widgets\n",
+    "from ipywidgets import interact"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Access a dataset\n",
+    "\n",
+    "With the TDS catalog url, we can use Siphon to get the dataset named `datasetName`.\\\n",
+    "Siphon's `remote-access` returns a `Dataset` object, which opens the remote dataset and provides access to its metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catUrl = \"{{catUrl}}\"\n",
+    "datasetName = \"{{datasetName}}\"\n",
+    "catalog = TDSCatalog(catUrl)\n",
+    "ds = catalog.datasets[datasetName]\n",
+    "dataset = ds.remote_access(use_xarray=True)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Standardized Data\n",
+    "\n",
+    "$z$: &ensp; Data point \\\n",
+    "$\\mu$: &ensp; Mean value in the variable \\\n",
+    "$\\sigma$: &ensp; Standard deviation value in the variable \\\n",
+    "$s$: &ensp; Standardized data point\n",
+    "\n",
+    "$s = \\cfrac{z - \\mu}{\\sigma}$"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### List of variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list(dataset.data_vars)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Display a variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dd = widgets.Dropdown(options = list(dataset.data_vars), description = 'Select a variable')\n",
+    "\n",
+    "def plot_variable(column):\n",
+    "\tif len(dataset[column].shape) > 2:\n",
+    "\t\tdataset[column].plot()\n",
+    "\t\n",
+    "interact(plot_variable, column = dd)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16 | packaged by conda-forge | (main, Feb  1 2023, 21:39:03) \n[GCC 11.3.0]"
+  },
+  "orig_nbformat": 4,
+  "viewer_info": {
+   "accepts": {
+    "accept_datasetIDs": [
+     "standardized.*"
+    ]
+   },
+   "description": "Preprocessed Dataset Visualization - Standardized"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b5cfa023891fceef02537f80a4c6e95b77988fb973cdb16a51cdb785092210be"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds notebooks for visualization of only preprocessed datasets that were included on threddsTest by https://github.com/Unidata/TdsConfig/pull/127 . 
The inclusion of these notebooks also closes the issue https://github.com/Unidata/netcdf-java/issues/1206 .