### PR TITLE
Add custom template fragments

### DIFF
--- a/thredds/templates/tdsTemplateFragments.html
+++ b/thredds/templates/tdsTemplateFragments.html
@@ -9,7 +9,7 @@
 
     <div th:fragment="banner" class="banner">
       <h2>
-        Welcome to the NSF Unidata Development THREDDS Data Server!
+        Welcome to the NSF Unidata THREDDS Data Server!
       </h2>
     </div>
 

--- a/threddsTest/templates/tdsTemplateFragments.html
+++ b/threddsTest/templates/tdsTemplateFragments.html
@@ -9,7 +9,7 @@
 
     <div th:fragment="banner" class="banner">
       <h2>
-        Welcome to the NSF Unidata Development THREDDS Data Server!
+        Welcome to the NSF Unidata Test THREDDS Data Server!
       </h2>
     </div>
 


### PR DESCRIPTION
Add custom template fragments for each of the three unidata thredds servers. Except for  thredds-dev, the ones currently used were not in git and the thredds-dev one seemed outdated. I copied the currently used version on [thredds-test](https://thredds-test.unidata.ucar.edu/thredds/catalog/catalog.html) for each of the three servers, with the banner text being the only difference between them ("Welcome to the NSF Unidata (Test/Development) THREDDS Data Server!")