### PR TITLE
Update S3 bucket name for NEXRAD AWS

### DIFF
--- a/awsL2/catalog.xml
+++ b/awsL2/catalog.xml
@@ -11,8 +11,7 @@
   </service>
 	 
   <datasetScan name="S3 NEXRAD Level II" collectionType="TimeSeries" ID="nexrad/level2/S3"
-	  path="nexrad/level2/S3" location="s3://noaa-nexrad-level2" serviceName="radar">
-    <crawlableDatasetImpl className="thredds.crawlabledataset.s3.CrawlableDatasetAmazonS3"/>
+    path="nexrad/level2/S3" location="cdms3:unidata-nexrad-level2#delimiter=/" serviceName="radar">
     <filter>
       <include regExp="\w{4}\d{8}_\d{6}(_V\d{2})?(\.gz)?$" />
     </filter>


### PR DESCRIPTION
This has migrated from noaa-nexrad-level2 to unidata-nexrad-level2.

Also go ahead and remove the now unused CrawlableDataset stuff.